### PR TITLE
Feat/thunk

### DIFF
--- a/graph/generate/cosmos_scalars.go
+++ b/graph/generate/cosmos_scalars.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"encoding/json"
 	"github.com/cosmos/cosmos-sdk/types"
-	"math/big"
 	"reflect"
 	"time"
 
@@ -34,28 +33,30 @@ type ScalarGeneratorPair struct {
 
 var lists = []ScalarGeneratorPair{
 	// bigint
-	{
-		Check: func(target reflect.Type, scalar *graphql.Scalar) bool {
-			t := reflect.TypeOf((*interface{ BigInt() *big.Int })(nil)).Elem()
-			if target.Implements(t) {
-				return true
-			}
-			return false
-		},
-		Scalar: graphql.NewScalar(graphql.ScalarConfig{
-			Name:        "BigInt",
-			Description: "BigInt scalar type represents cosmos-sdk specific big int implementation",
-			Serialize: func(value interface{}) interface{} {
-				return value
-			},
-			ParseValue: func(value interface{}) interface{} {
-				return value
-			},
-			ParseLiteral: func(valueAST ast.Value) interface{} {
-				return valueAST.GetValue()
-			},
-		}),
-	},
+	// {
+	// 	Check: func(target reflect.Type, scalar *graphql.Scalar) bool {
+	// 		if target == reflect.TypeOf((*types.Int)(nil)).Elem() {
+	// 			return true
+	// 		} else {
+	// 			return false
+	// 		}
+	// 	},
+	// 	Scalar: graphql.NewScalar(graphql.ScalarConfig{
+	// 		Name:        "BigInt",
+	// 		Description: "BigInt scalar type represents cosmos-sdk specific big int implementation",
+	// 		Serialize: func(value interface{}) interface{} {
+	// 			return value
+	// 		},
+	// 		ParseValue: func(value interface{}) interface{} {
+	// 			return value
+	// 		},
+	// 		ParseLiteral: func(valueAST ast.Value) interface{} {
+	// 			return valueAST.GetValue()
+	// 		},
+	// 	}),
+	// },
+
+
 
 	// StdTx/Msg
 	{

--- a/graph/utils.go
+++ b/graph/utils.go
@@ -29,7 +29,7 @@ type ThunkResult struct {
 	data interface{}
 	err error
 }
-func CreateThunk(thunk Thunk) (Thunk, error) {
+func CreateThunk(thunk Thunk) (func() (interface{}, error), error) {
 	ch := make(chan *ThunkResult, 1)
 
 	go func() {

--- a/graph/utils.go
+++ b/graph/utils.go
@@ -4,6 +4,7 @@ import (
 	"github.com/terra-project/mantle-sdk/serdes"
 	"github.com/terra-project/mantle-sdk/types"
 	"reflect"
+	"sync"
 )
 
 func UnmarshalInternalQueryResult(result *types.GraphQLInternalResult, target interface{}) error {
@@ -45,4 +46,70 @@ func CreateThunk(thunk Thunk) (Thunk, error) {
 		r := <-ch
 		return r.data, r.err
 	}, nil
+}
+
+
+func CreateParallel(len int) *parallelExecutionContext {
+	wg := &sync.WaitGroup{}
+	wg.Add(len)
+	return &parallelExecutionContext{
+		RWMutex: sync.RWMutex{},
+		idx:     0,
+		wg:      wg,
+		result:  make([]ParallelExecutionResult, len),
+	}
+}
+
+type parallelExecutionContext struct {
+	sync.RWMutex
+	idx int64
+	wg *sync.WaitGroup
+	result []ParallelExecutionResult
+	errorExists bool
+	done bool
+}
+
+type ParallelExecutionFunc func() (interface{}, error)
+type ParallelExecutionResult struct {
+	Result interface{}
+	Error error
+}
+
+func (pec *parallelExecutionContext) Run(f ParallelExecutionFunc) {
+	if pec.done {
+		panic("cannot add more runners. parallel execution is already done.")
+	}
+
+	i := pec.idx
+	pec.idx = pec.idx + 1
+
+	// run goroutine
+	go func() {
+		defer pec.wg.Done()
+
+		r, e := f()
+
+		pec.RWMutex.Lock()
+		var result ParallelExecutionResult
+		if e != nil {
+			result = ParallelExecutionResult{ Error: e }
+			pec.errorExists = true
+		} else {
+			result = ParallelExecutionResult{ Result: r }
+		}
+
+		pec.result[i] = result
+		pec.RWMutex.Unlock()
+	}()
+}
+
+func (pec *parallelExecutionContext) HasErrors() bool {
+	return pec.errorExists
+}
+
+func (pec *parallelExecutionContext) Sync() []ParallelExecutionResult {
+	pec.done = true
+	pec.wg.Wait()
+
+	return pec.result
 }

--- a/graph/utils_test.go
+++ b/graph/utils_test.go
@@ -1,0 +1,32 @@
+package graph
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestCreateParallel(t *testing.T) {
+	parallel := CreateParallel(5)
+
+	start := time.Now()
+	// should take about 5 seconds
+	for i:=0; i<5; i++ {
+		c := i
+		parallel.Run(func() (interface{}, error) {
+			time.Sleep(time.Duration(i) * time.Second)
+			return c, nil
+		})
+	}
+
+	results := parallel.Sync()
+	end := time.Now()
+
+	assert.WithinDuration(t, end, start, time.Duration(6) * time.Second)
+	for i, r := range results {
+		assert.Equal(t, i, r.Result)
+		assert.Nil(t, r.Error)
+	}
+
+	assert.False(t, parallel.HasErrors())
+}


### PR DESCRIPTION
thunk parallelises abci queries and execution.

- by default, graphql resolvers are synchronous. for this reason certain ABCIQueries are synchronously executed (i.e WasmContractStore) resulting in super slow graphql resolve.
- also for listgen resolvers, added parallel handlers for concurrent db iteration.